### PR TITLE
Fix numpy 2 compatibility

### DIFF
--- a/recipe/guiqwt-numpy2.patch
+++ b/recipe/guiqwt-numpy2.patch
@@ -1,0 +1,125 @@
+diff --git a/guiqwt/curve.py b/guiqwt/curve.py
+index be388c7..b95ff9b 100644
+--- a/guiqwt/curve.py
++++ b/guiqwt/curve.py
+@@ -496,8 +496,8 @@ class CurveItem(QwtPlotCurve):
+             * x: NumPy array
+             * y: NumPy array
+         """
+-        self._x = np.array(x, copy=False)
+-        self._y = np.array(y, copy=False)
++        self._x = np.asarray(x)
++        self._y = np.asarray(y)
+         self.setData(self._x, self._y)
+ 
+     def is_empty(self):
+@@ -774,9 +774,9 @@ class PolygonMapItem(QwtPlotItem):
+             * x: NumPy array
+             * y: NumPy array
+         """
+-        self._pts = np.array(pts, copy=False)
+-        self._n = np.array(n, copy=False)
+-        self._c = np.array(c, copy=False)
++        self._pts = np.asarray(pts)
++        self._n = np.asarray(n)
++        self._c = np.asarray(c)
+         xmin, ymin = self._pts.min(axis=0)
+         xmax, ymax = self._pts.max(axis=0)
+         self.bounds = QRectF(xmin, ymin, xmax - xmin, ymax - ymin)
+@@ -948,11 +948,11 @@ class ErrorBarCurveItem(CurveItem):
+         """
+         CurveItem.set_data(self, x, y)
+         if dx is not None:
+-            dx = np.array(dx, copy=False)
++            dx = np.asarray(dx)
+             if dx.size == 0:
+                 dx = None
+         if dy is not None:
+-            dy = np.array(dy, copy=False)
++            dy = np.asarray(dy)
+             if dy.size == 0:
+                 dy = None
+         self._dx = dx
+diff --git a/guiqwt/label.py b/guiqwt/label.py
+index 5bc31b5..d2dd42c 100644
+--- a/guiqwt/label.py
++++ b/guiqwt/label.py
+@@ -575,7 +575,7 @@ class RangeComputation(ObjectInfo):
+             elif i0 == i1:
+                 import numpy as np
+ 
+-                vectors.append(np.array([np.NaN]))
++                vectors.append(np.array([np.nan]))
+             else:
+                 vectors.append(vector[i0:i1])
+         return self.label % self.func(*vectors)
+diff --git a/guiqwt/plot.py b/guiqwt/plot.py
+index 85766c4..7eb8eaf 100644
+--- a/guiqwt/plot.py
++++ b/guiqwt/plot.py
+@@ -100,7 +100,7 @@ Reference
+ """
+ 
+ import weakref
+-from numpy.lib.arraysetops import isin
++from numpy import isin
+ 
+ from qtpy.QtWidgets import (
+     QDialogButtonBox,
+diff --git a/guiqwt/tests/computations.py b/guiqwt/tests/computations.py
+index bfe00f4..cf54543 100644
+--- a/guiqwt/tests/computations.py
++++ b/guiqwt/tests/computations.py
+@@ -29,7 +29,11 @@ def test():
+ 
+     _app = guidata.qapplication()
+     # --
+-    from numpy import linspace, sin, trapz
++    from numpy import linspace, sin
++    try:
++        from numpy import trapz
++    except ImportError:
++        import numpy.trapezoid as trapz
+ 
+     x = linspace(-10, 10, 1000)
+     y = sin(sin(sin(x)))
+diff --git a/guiqwt/tests/mandelbrot.py b/guiqwt/tests/mandelbrot.py
+index 1a70e47..d9cd51a 100644
+--- a/guiqwt/tests/mandelbrot.py
++++ b/guiqwt/tests/mandelbrot.py
+@@ -56,7 +56,7 @@ class MandelItem(RawImageItem):
+         NX = x2 - x1
+         NY = y2 - y1
+         if self.data.shape != (NX, NY):
+-            self.data = np.zeros((NY, NX), np.uint8)
++            self.data = np.zeros((NY, NX), np.int8)
+         mandelbrot(i1, j1, i2, j2, self.data, self.IMAX)
+ 
+         srcRect = (0, 0, NX, NY)
+diff --git a/guiqwt/tools.py b/guiqwt/tools.py
+index 21d12a4..a22d408 100644
+--- a/guiqwt/tools.py
++++ b/guiqwt/tools.py
+@@ -243,6 +243,11 @@ import numpy as np
+ import weakref
+ import os.path as osp
+ 
++try:
++    from numpy import trapz
++except ImportError:
++    import numpy.trapezoid as trapz
++
+ from qtpy.QtCore import Qt, QObject, QPointF, Signal
+ from qtpy.QtGui import QKeySequence
+ from qtpy.QtPrintSupport import QPrinter, QPrintDialog
+@@ -1427,8 +1432,8 @@ class SignalStatsTool(BaseCursorTool):
+                     ),
+                     (curve, "&lt;y&gt;=%g", lambda *args: args[1].mean()),
+                     (curve, "σ(y)=%g", lambda *args: args[1].std()),
+-                    (curve, "∑(y)=%g", lambda *args: np.trapz(args[1])),
+-                    (curve, "∫ydx=%g", lambda *args: np.trapz(args[1], args[0])),
++                    (curve, "∑(y)=%g", lambda *args: trapz(args[1])),
++                    (curve, "∫ydx=%g", lambda *args: trapz(args[1], args[0])),
+                 ],
+             )
+             self.label.attach(plot)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,10 +7,12 @@ package:
 source:
   url: https://github.com/PierreRaybaut/guiqwt/archive/refs/tags/v{{ version }}.tar.gz
   sha256: 128c115e0f1ced462a321675a3a3ae79cb57f83154a967f96e4227057cce5f6b
+  patches:
+    - guiqwt-numpy2.patch
 
 build:
   skip: true  # [win and vc<14]
-  number: 3
+  number: 4
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
@@ -28,10 +30,10 @@ requirements:
     - setuptools
     - numpy
     - cython
-    - guidata ==3.1
+    - guidata >=3.5.2,<=3.9.0
     - pyqt
   run:
-    - guidata ==3.1
+    - guidata >=3.5.2,<=3.9.0
     - pillow
     - python
     - pythonqwt >=0.10,<0.14.4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,10 +43,6 @@ requirements:
 test:
   imports:
     - guiqwt
-  requires:
-    - pip
-  commands:
-    - pip check
 
 about:
   home: https://github.com/PierreRaybaut/guiqwt


### PR DESCRIPTION

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

guiqwt 4.4.5 isn't maintained anymore and I noticed numpy 2 compatibility issues in taurus (images weren't displayed):
- add a patch to fix obvious issues
- change guidata required version (numpy 2 support added in guidata 3.5.2 - didn't see any breaking changes up to 3.9.0 which is current one). Pinning to 3.1 as done in setup.py seems to be over precautious). I ran guiqwt tests with guidata 3.9.0 (which fixed some (simple_window.py / sift.py)